### PR TITLE
Update Windows README with complete file list and SSL certificate info

### DIFF
--- a/win64-dist/README.txt
+++ b/win64-dist/README.txt
@@ -5,13 +5,17 @@ This is Lynx 2.9.2 built with PDCurses SDL2 backend for Windows.
 Japanese text display and input (IME) are supported.
 
 Files:
-  lynx.exe       - Main executable
-  lynx.cfg       - Configuration file (font, charset settings)
-  SDL2.dll       - SDL2 library
-  SDL2_ttf.dll   - SDL2 TrueType font library
-  fonts/         - Bundled fonts
+  lynx.exe             - Main executable
+  lynx.cfg             - Configuration file (font, charset settings)
+  lynx.lss             - Color style sheet
+  lynx-sdl.bmp         - Window icon
+  SDL2.dll             - SDL2 library
+  SDL2_ttf.dll         - SDL2 TrueType font library
+  libssl-3-x64.dll     - OpenSSL SSL library
+  libcrypto-3-x64.dll  - OpenSSL crypto library
+  fonts/               - Bundled fonts
     NotoSansMonoCJKjp-Regular.otf - Japanese monospace font (SIL OFL)
-    LICENSE      - Font license file
+    LICENSE            - Font license file
 
 Usage:
   Double-click lynx.exe to start Lynx.
@@ -27,11 +31,25 @@ Configuration (lynx.cfg):
   CHARACTER_SET  - Display charset (default: utf-8)
   ASSUME_CHARSET - Assumed document charset (default: utf-8)
 
-  To use a different font, edit lynx.cfg:
-    PDC_FONT:C:\Windows\Fonts\msgothic.ttc
+  To use a different font, copy the font file to the fonts/ directory
+  and edit lynx.cfg:
+    PDC_FONT:fonts\YourFont.ttf
+
+  Note: Windows 11 restricts user access to C:\Windows\Fonts.
+
+SSL Certificates:
+  This program does not include server certificates.
+  You can obtain CA certificates from:
+    https://curl.haxx.se/docs/caextract.html
+
+  Download the cacert.pem file and save it as "cert.pem" in the Lynx
+  installation directory (same directory as lynx.exe).
+
+  For more details about root certificates, see docs/README.rootcerts.
 
 License:
   Lynx: GPLv2
   PDCurses: Public Domain
   SDL2: zlib License
+  OpenSSL: Apache License 2.0
   Noto Sans Mono CJK JP: SIL Open Font License (OFL)


### PR DESCRIPTION
## Summary
- Add missing distribution files to the file list (lynx.lss, lynx-sdl.bmp, OpenSSL DLLs)
- Add SSL certificate section explaining how to obtain CA certs from curl.haxx.se and install them
- Fix font configuration example for Windows 11 compatibility (removed C:\Windows\Fonts reference)
- Add OpenSSL to the license section

## Test plan
- [x] Verify README.txt content is accurate and complete
- [x] Confirm all listed files exist in win64-dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)