### PR TITLE
Add zlib support to fix Accept-Encoding: gzip on Windows (fixes #10)

### DIFF
--- a/BUILDING-WIN64
+++ b/BUILDING-WIN64
@@ -39,6 +39,28 @@ STEP 0: DOWNLOAD REQUIRED LIBRARIES (first time only)
        tar -I zstd -xf mingw-w64-x86_64-libiconv-1.17-4-any.pkg.tar.zst
        mv mingw64 libiconv-1.17
 
+   zlib (for inline gzip decompression; enables Accept-Encoding: gzip):
+       curl -L -o zlib-1.3.1.tar.gz https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz
+       tar xzf zlib-1.3.1.tar.gz
+       cd zlib-1.3.1
+       make -f win32/Makefile.gcc \
+         PREFIX=x86_64-w64-mingw32- \
+         CC=x86_64-w64-mingw32-gcc \
+         AR=x86_64-w64-mingw32-ar \
+         ARFLAGS=rcs \
+         STRIP=x86_64-w64-mingw32-strip \
+         BINARY_PATH=../zlib-1.3.1/bin \
+         INCLUDE_PATH=../zlib-1.3.1/include \
+         LIBRARY_PATH=../zlib-1.3.1/lib \
+         SHARED_MODE=0
+       make install -f win32/Makefile.gcc \
+         BINARY_PATH=../zlib-1.3.1/bin \
+         INCLUDE_PATH=../zlib-1.3.1/include \
+         LIBRARY_PATH=../zlib-1.3.1/lib \
+         SHARED_MODE=0
+       cd ..
+       # Note: zlib is linked statically; no DLL is needed in win64-dist/
+
 STEP 1: BUILD PDCURSES
 
    cd PDCurses/sdl2

--- a/WWW/Library/Implementation/HTTP.c
+++ b/WWW/Library/Implementation/HTTP.c
@@ -400,6 +400,10 @@ static BOOL acceptEncoding(int code)
 
 	switch (code) {
 	case encodingGZIP:
+#ifdef USE_ZLIB
+	    result = TRUE;
+	    break;
+#endif
 	    program = HTGetProgramPath(ppGZIP);
 	    break;
 	case encodingDEFLATE:
@@ -420,7 +424,8 @@ static BOOL acceptEncoding(int code)
 	default:
 	    break;
 	}
-	result = (BOOL) (program != NULL);
+	if (!result)
+	    result = (BOOL) (program != NULL);
     }
     return result;
 }

--- a/configure_win64.sh
+++ b/configure_win64.sh
@@ -6,6 +6,7 @@ SDL2_DIR=/home/patakuti/CCROOT/lynx-sdl2/win64-libs/SDL2-2.30.10/x86_64-w64-ming
 SDL2_TTF_DIR=/home/patakuti/CCROOT/lynx-sdl2/win64-libs/SDL2_ttf-2.22.0/x86_64-w64-mingw32
 OPENSSL_DIR=/home/patakuti/CCROOT/lynx-sdl2/win64-libs/openssl-3.4.1
 ICONV_DIR=/home/patakuti/CCROOT/lynx-sdl2/win64-libs/libiconv-1.17
+ZLIB_DIR=/home/patakuti/CCROOT/lynx-sdl2/win64-libs/zlib-1.3.1
 WIN64_BUILD=/home/patakuti/CCROOT/lynx-sdl2/win64-build
 
 ./configure \
@@ -14,8 +15,9 @@ WIN64_BUILD=/home/patakuti/CCROOT/lynx-sdl2/win64-build
   --enable-widec \
   --enable-wcwidth-support \
   --with-ssl="${OPENSSL_DIR}" \
+  --with-zlib="${ZLIB_DIR}" \
   --without-x \
   --disable-nls \
-  CPPFLAGS="-I${PDCURSES_DIR} -I${SDL2_DIR}/include/SDL2 -I${SDL2_TTF_DIR}/include/SDL2 -I${OPENSSL_DIR}/include -I${ICONV_DIR}/include -DPDCURSES -DPDCURSES_SDL2 -DPDC_WIDE -DPDC_FORCE_UTF8 -DUSE_PROGRAM_DIR -DUSE_OPENSSL_INCL -DEXP_WCWIDTH_SUPPORT=1 -DUSE_WCWIDTH_SUPPORT=1" \
-  LDFLAGS="-L${WIN64_BUILD} -L${SDL2_DIR}/lib -L${SDL2_TTF_DIR}/lib -L${OPENSSL_DIR}/lib -L${ICONV_DIR}/lib -mwindows" \
+  CPPFLAGS="-I${PDCURSES_DIR} -I${SDL2_DIR}/include/SDL2 -I${SDL2_TTF_DIR}/include/SDL2 -I${OPENSSL_DIR}/include -I${ICONV_DIR}/include -I${ZLIB_DIR}/include -DPDCURSES -DPDCURSES_SDL2 -DPDC_WIDE -DPDC_FORCE_UTF8 -DUSE_PROGRAM_DIR -DUSE_OPENSSL_INCL -DEXP_WCWIDTH_SUPPORT=1 -DUSE_WCWIDTH_SUPPORT=1" \
+  LDFLAGS="-L${WIN64_BUILD} -L${SDL2_DIR}/lib -L${SDL2_TTF_DIR}/lib -L${OPENSSL_DIR}/lib -L${ICONV_DIR}/lib -L${ZLIB_DIR}/lib -mwindows" \
   LIBS="-lpdcurses -lSDL2 -lSDL2_ttf -liconv"

--- a/src/HTFWriter.c
+++ b/src/HTFWriter.c
@@ -1426,6 +1426,10 @@ HTStream *HTCompressed(HTPresentation *pres,
 	    can_present = TRUE;
 	    switch (HTEncodingToCompressType(anchor->content_encoding)) {
 	    case cftGzip:
+#ifdef USE_ZLIB
+		compress_suffix = "gz";	/* zlib handles inline decompression */
+		break;
+#endif
 		if ((program = HTGetProgramPath(ppGZIP)) != NULL) {
 		    /*
 		     * It's compressed with the modern gzip.  - FM
@@ -1482,7 +1486,7 @@ HTStream *HTCompressed(HTPresentation *pres,
 	}
     }
     if (can_present == FALSE ||	/* no presentation mapping */
-	uncompress_mask == NULL ||	/* not gzip or compress */
+	(uncompress_mask == NULL && *compress_suffix == '\0') ||	/* not gzip or compress */
 	StrChr(anchor->content_type, ';') ||	/* wrong charset */
 	HTOutputFormat == WWW_DOWNLOAD ||	/* download */
 	!strcasecomp(pres->rep_out->name, STR_DOWNLOAD) ||	/* download */


### PR DESCRIPTION
## Summary

- Closes #10
- Cross-compile zlib 1.3.1 for Windows x64 and enable `USE_ZLIB` at build time
- Fix `acceptEncoding()` to advertise gzip without requiring an external `gzip.exe`
- Fix `HTCompressed()` to decompress gzip responses inline via zlib

## Background

The Windows build sent no `Accept-Encoding` header because `acceptEncoding()`
gated the header on finding an external `gzip.exe` via `HTGetProgramPath()`.
DataDome bot-protection (used by sites such as jp.reuters.com) flags this
absence and returns 401.  Ubuntu Lynx, which has `/usr/bin/gzip` in PATH,
was unaffected.

Even after the first fix, gzip-encoded responses prompted
"application/x-gzip — D)ownload or C)ancel" because `HTCompressed()` also
required the external program to set `compress_suffix="gz"` and to set
`end_command`.

## Changes

| File | Change |
|------|--------|
| `configure_win64.sh` | Add `ZLIB_DIR`, `--with-zlib`, zlib include/lib paths |
| `WWW/Library/Implementation/HTTP.c` | `acceptEncoding()`: return TRUE for gzip when `USE_ZLIB` is defined |
| `src/HTFWriter.c` | `HTCompressed()`: set `compress_suffix="gz"` under `USE_ZLIB`; relax fallback condition from `uncompress_mask==NULL` to `uncompress_mask==NULL && *compress_suffix=='\0'` |
| `BUILDING-WIN64` | Add zlib 1.3.1 cross-compile steps to STEP 0 |

## Test plan

- [x] `Accept-Encoding: gzip` appears in HTTP requests (confirmed via trace log)
- [x] jp.reuters.com returns 200 and displays content (confirmed)
- [x] Gzip-encoded responses are decompressed and rendered inline (confirmed)
- [x] Sites without gzip encoding continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)